### PR TITLE
Add link to task group inspector for submitted phases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build
 node_modules
 *.swp
 .idea/
+yarn-error.log

--- a/src/config.js
+++ b/src/config.js
@@ -5,4 +5,5 @@ export const AUTH_CONFIG = {
   scope: 'full-user-credentials openid profile email',
 };
 export const TREEHERDER_URL = 'https://treeherder.mozilla.org';
+export const TASKCLUSTER_TOOLS_URL = 'https://tools.taskcluster.net';
 export const { API_URL } = process.env;

--- a/src/views/ListReleases/index.js
+++ b/src/views/ListReleases/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { ProgressBar, Button, Modal } from 'react-bootstrap';
 import { object } from 'prop-types';
 import ReactInterval from 'react-interval';
-import { TREEHERDER_URL, API_URL } from '../../config';
+import { TREEHERDER_URL, TASKCLUSTER_TOOLS_URL, API_URL } from '../../config';
 
 const statusStyles = {
   true: 'success',
@@ -92,7 +92,7 @@ const TaskProgress = (props) => {
   const width = 100 / phases.length;
   return (
     <ProgressBar style={{ height: '40px', padding: '3px' }}>
-      {phases.map(({ name, submitted }) => (
+      {phases.map(({ name, submitted, actionTaskId }) => (
         <ProgressBar
           key={name}
           bsStyle={statusStyles[submitted]}
@@ -101,6 +101,7 @@ const TaskProgress = (props) => {
           label={<TaskLabel
             name={name}
             submitted={submitted}
+            taskGroupUrl={`${TASKCLUSTER_TOOLS_URL}/groups/${actionTaskId}`}
             url={`${API_URL}/releases/${releaseName}/${name}`}
           />}
         />
@@ -199,6 +200,6 @@ class TaskLabel extends React.PureComponent {
         </div>
       );
     }
-    return <div>{this.props.name}</div>;
+    return <div>{this.props.name} - <a href={this.props.taskGroupUrl}>Task Group</a></div>;
   }
 }


### PR DESCRIPTION
This depends on https://github.com/mozilla-releng/services/pull/1035 for backend support. It's ugly, but no uglier than the current UI :stuck_out_tongue: 